### PR TITLE
Updated usage of deprecated and modified Gym functions

### DIFF
--- a/eval_policy.py
+++ b/eval_policy.py
@@ -1,3 +1,4 @@
+import torch
 """
 	This file is used only to evaluate our trained policy/actor after
 	training in main.py with ppo.py. I wrote this file to demonstrate
@@ -51,6 +52,7 @@ def rollout(policy, env, render):
 	# Rollout until user kills process
 	while True:
 		obs = env.reset()
+		obs = torch.tensor(obs[0])
 		done = False
 
 		# number of timesteps so far
@@ -69,7 +71,7 @@ def rollout(policy, env, render):
 
 			# Query deterministic action from policy and run it
 			action = policy(obs).detach().numpy()
-			obs, rew, done, _ = env.step(action)
+			obs, rew, done, _, _ = env.step(action)
 
 			# Sum all episodic rewards as we go along
 			ep_ret += rew

--- a/main.py
+++ b/main.py
@@ -108,7 +108,7 @@ def main(args):
 	# Creates the environment we'll be running. If you want to replace with your own
 	# custom environment, note that it must inherit Gym and have both continuous
 	# observation and action spaces.
-	env = gym.make('Pendulum-v0')
+	env = gym.make('BipedalWalker-v3', render_mode="human")
 
 	# Train or test, depending on the mode specified
 	if args.mode == 'train':

--- a/ppo.py
+++ b/ppo.py
@@ -6,6 +6,7 @@
 
 import gym
 import time
+import os
 
 import numpy as np
 import time
@@ -184,6 +185,7 @@ class PPO:
 
 			# Reset the environment. sNote that obs is short for observation. 
 			obs = self.env.reset()
+			obs = torch.tensor(obs[0])
 			done = False
 
 			# Run an episode for a maximum of max_timesteps_per_episode timesteps
@@ -200,7 +202,7 @@ class PPO:
 				# Calculate action and make a step in the env. 
 				# Note that rew is short for reward.
 				action, log_prob = self.get_action(obs)
-				obs, rew, done, _ = self.env.step(action)
+				obs, rew, done, _, _ = self.env.step(action)
 
 				# Track recent reward, action, and action log probability
 				ep_rews.append(rew)
@@ -216,8 +218,9 @@ class PPO:
 			batch_rews.append(ep_rews)
 
 		# Reshape data as tensors in the shape specified in function description, before returning
-		batch_obs = torch.tensor(batch_obs, dtype=torch.float)
-		batch_acts = torch.tensor(batch_acts, dtype=torch.float)
+		batch_obs = convertToTensor(batch_obs)
+		#batch_acts = torch.tensor(batch_acts, dtype=torch.float)
+		batch_acts = convertToTensor(batch_acts)
 		batch_log_probs = torch.tensor(batch_log_probs, dtype=torch.float)
 		batch_rtgs = self.compute_rtgs(batch_rews)                                                              # ALG STEP 4
 
@@ -397,3 +400,22 @@ class PPO:
 		self.logger['batch_lens'] = []
 		self.logger['batch_rews'] = []
 		self.logger['actor_losses'] = []
+
+def convertToTensor(list):
+	'''
+
+	Args:
+		list: an array of 1D tensors
+
+	Returns: a 2D tensor
+
+	'''
+	ans = []
+	temp = []
+	for i in range(len(list)):
+		temp = []
+		for j in range(len(list[i])):
+			temp.append(list[i][j])
+		ans.append(temp)
+	return torch.tensor(ans)
+


### PR DESCRIPTION
The OpenAI Gym has modified the output fields of an environment's observations, resulting in some minor yet frustrating data type conflicts between PyTorch tensors, arrays, and numpy arrays. I have made a few adjustments to the observation collection logic to resolve the issue. I also added a very simple (possibly slow) helper method to fix Pytorch's reluctance to convert an array of tensors to a 2D tensor.